### PR TITLE
Normalize DataFrame dtypes and add LangChain chat thread

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base="dark"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# LLM Data Visualizer
 
+This Streamlit application lets you upload a CSV or Excel file and chat with a locally hosted `meta-llama/Llama-3.1-8B-Instruct` model (served by vLLM at `localhost:8000`) to create Plotly visuals. A ReAct agent reviews each visualization for accuracy and relevance and shares its reasoning.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Ensure a vLLM server is running locally:
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000
+```
+
+## Running
+
+```bash
+streamlit run app.py
+```
+
+Upload your dataset, then converse with the model about the chart you want. Each response returns the Python code used to build the Plotly figure, shows the chart, and displays the agent's review and chain of thought.

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,57 @@
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from langchain_openai import ChatOpenAI
+from langchain.schema import HumanMessage, SystemMessage
+
+
+@dataclass
+class ReviewResult:
+    review: str
+    thoughts: str
+
+
+class ReviewAgent:
+    """ReAct-style agent that critiques a Plotly visualization."""
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000/v1",
+        model: str = "meta-llama/Llama-3.1-8B-Instruct",
+    ) -> None:
+        api_key = os.getenv("OPENAI_API_KEY", "llm")
+        self.llm = ChatOpenAI(base_url=base_url, api_key=api_key, model=model)
+
+    def _chat(self, messages: list) -> str:
+        response = self.llm.invoke(messages)
+        return response.content.strip()
+
+    def review_visual(self, prompt: str, figure_spec: Dict[str, Any]) -> ReviewResult:
+        fig_json = json.dumps(figure_spec)
+        messages = [
+            SystemMessage(
+                content=(
+                    "You are a ReAct agent that reviews data visualizations. "
+                    "Use step-by-step reasoning to determine if the visualization is accurate and relevant to the user's prompt. "
+                    "Respond in JSON with keys 'review' and 'thoughts'."
+                )
+            ),
+            HumanMessage(
+                content=(
+                    f"User prompt: {prompt}\n" +
+                    f"Visualization spec (Plotly JSON): {fig_json}"
+                )
+            ),
+        ]
+        content = self._chat(messages)
+        try:
+            data = json.loads(content)
+            review = data.get("review", "")
+            thoughts = data.get("thoughts", "")
+        except json.JSONDecodeError:
+            review = content
+            thoughts = ""
+        return ReviewResult(review=review, thoughts=thoughts)
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,134 @@
+import os
+import re
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+from langchain.schema import AIMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+
+from agent import ReviewAgent
+
+st.set_page_config(page_title="LLM Plotter", layout="wide")
+
+st.title("LLM Data Visualizer")
+
+
+def ensure_consistent_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    """Coerce each DataFrame column to a single dtype."""
+    for col in df.columns:
+        series = df[col]
+        try:
+            df[col] = pd.to_numeric(series, errors="raise")
+            continue
+        except (ValueError, TypeError):
+            pass
+        try:
+            df[col] = pd.to_datetime(series, errors="raise")
+            continue
+        except (ValueError, TypeError):
+            pass
+        df[col] = series.astype(str)
+    return df
+
+
+def extract_code(text: str) -> str:
+    pattern = r"```(?:python)?\n(.*?)```"
+    match = re.search(pattern, text, re.DOTALL)
+    return match.group(1).strip() if match else text.strip()
+
+
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+if "df" not in st.session_state:
+    st.session_state.df = None
+if "system_message" not in st.session_state:
+    st.session_state.system_message = None
+if "last_fig" not in st.session_state:
+    st.session_state.last_fig = None
+if "last_review" not in st.session_state:
+    st.session_state.last_review = None
+if "last_thoughts" not in st.session_state:
+    st.session_state.last_thoughts = None
+
+
+uploaded = st.file_uploader("Upload CSV or Excel", type=["csv", "xlsx", "xls"])
+
+if uploaded and st.session_state.df is None:
+    try:
+        if uploaded.name.endswith(".csv"):
+            df = pd.read_csv(uploaded)
+        else:
+            df = pd.read_excel(uploaded)
+        df = ensure_consistent_dtypes(df)
+        st.session_state.df = df
+        preview = df.head().to_csv(index=False)
+        st.session_state.system_message = SystemMessage(
+            content=(
+                "You are a data visualization expert using Plotly in Python. "
+                f"Use the following data sample:\n{preview}\n" \
+                "Return only Python code that creates a Plotly figure assigned to variable 'fig'."
+            )
+        )
+        st.session_state.messages = []
+    except Exception as e:
+        st.error(f"Error: {e}")
+        print(e)
+
+
+df = st.session_state.df
+if df is not None:
+    st.dataframe(df.head())
+
+
+chat = ChatOpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key=os.getenv("OPENAI_API_KEY", "llm"),
+    model="meta-llama/Llama-3.1-8B-Instruct",
+)
+
+for msg in st.session_state.messages:
+    role = "user" if isinstance(msg, HumanMessage) else "assistant"
+    with st.chat_message(role):
+        if role == "assistant":
+            st.code(msg.content, language="python")
+        else:
+            st.markdown(msg.content)
+
+
+user_input = st.chat_input("Describe a visualization") if df is not None else None
+
+if user_input:
+    human_msg = HumanMessage(user_input)
+    st.session_state.messages.append(human_msg)
+    with st.chat_message("user"):
+        st.markdown(user_input)
+
+    conversation = [st.session_state.system_message] + st.session_state.messages
+    ai_msg = chat.invoke(conversation)
+    code = extract_code(ai_msg.content)
+    st.session_state.messages.append(AIMessage(code))
+
+    local_vars = {"df": df, "px": px, "go": go}
+    try:
+        exec(code, local_vars)
+        fig = local_vars.get("fig")
+        st.session_state.last_fig = fig
+        if fig is not None:
+            review = ReviewAgent().review_visual(user_input, fig.to_dict())
+            st.session_state.last_review = review.review
+            st.session_state.last_thoughts = review.thoughts
+    except Exception as e:
+        st.error(f"Error: {e}")
+        print(e)
+
+
+if st.session_state.last_fig is not None:
+    st.plotly_chart(st.session_state.last_fig, use_container_width=True)
+    if st.session_state.last_review:
+        st.subheader("Agent Review")
+        st.markdown(st.session_state.last_review)
+        st.subheader("Agent Chain of Thought")
+        st.markdown(st.session_state.last_thoughts)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+streamlit
+pandas
+plotly
+openai
+openpyxl
+langchain
+langchain-openai


### PR DESCRIPTION
## Summary
- use LangChain ChatOpenAI with in-memory chat history for Plotly chart generation
- port ReAct review agent to LangChain
- document chat workflow and add required dependencies

## Testing
- `python -m py_compile agent.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b7bcb33c8832f8669cbec7a56b7dd