### PR TITLE
Use LangChain memory for chat-based visualization

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,56 +1,27 @@
-import json
-import os
-
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
-from PIL.Image import register_extension
-from openai import OpenAI
+from langchain.memory import ConversationBufferMemory
+from langchain.schema import HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
 
-from agent import ReviewAgent
 
 st.set_page_config(page_title="LLM Plotter", layout="wide")
-
 st.title("LLM Data Visualizer")
 
-uploaded = st.file_uploader("Upload CSV or Excel", type=["csv", "xlsx", "xls"])
-prompt = st.text_input("Describe the visualization you want")
 
-client = OpenAI()
-agent = ReviewAgent()
+def ensure_session_state() -> None:
+    """Initialize Streamlit session state for chat and memory."""
+    if "llm" not in st.session_state:
+        st.session_state.llm = ChatOpenAI(model="gpt-5", temperature=0)
+    if "memory" not in st.session_state:
+        st.session_state.memory = ConversationBufferMemory(return_messages=True)
+    if "chat_history" not in st.session_state:
+        st.session_state.chat_history = []
+    if "df" not in st.session_state:
+        st.session_state.df = None
 
-
-def generate_plot(df: pd.DataFrame, user_prompt: str):
-    preview = df.head().to_csv(index=False)
-    messages = [
-        {
-            "role": "system",
-            "content": "You are a data visualization expert using Plotly in Python.",
-        },
-        {
-            "role": "user",
-            "content": (
-                "Given the following data sample:\n" + preview +
-                f"\nCreate Plotly code that uses the whole dataset to satisfy the instruction: {user_prompt}. "
-                "Use variable df for the dataset."
-                "Assign the resulting Plotly figure to a variable named 'fig'."
-                "Answer with just the code."
-            ),
-        },
-    ]
-    response = client.chat.completions.create(
-        model="gpt-5",
-        messages=messages,
-    )
-    code = response.choices[0].message.content
-    local_vars = {"df": df, "px": px, "go": go}
-    code = code.replace("```", "") \
-    .replace("python", "", 1)
-    print(code)
-    exec(code, local_vars)
-    fig = local_vars.get("fig")
-    return fig, code
 
 def ensure_consistent_dtypes(df: pd.DataFrame) -> pd.DataFrame:
     """Coerce each DataFrame column to a single dtype."""
@@ -69,23 +40,81 @@ def ensure_consistent_dtypes(df: pd.DataFrame) -> pd.DataFrame:
         df[col] = series.astype(str)
     return df
 
-if uploaded and prompt:
+
+def generate_plot(
+    llm: ChatOpenAI,
+    memory: ConversationBufferMemory,
+    df: pd.DataFrame,
+    user_prompt: str,
+):
+    preview = df.head().to_csv(index=False)
+    messages = [
+        SystemMessage(content="You are a data visualization expert using Plotly in Python."),
+        *memory.chat_memory.messages,
+        HumanMessage(
+            content=(
+                "Given the following data sample:\n" + preview +
+                f"\nCreate Plotly code that uses the whole dataset to satisfy the instruction: {user_prompt}. "
+                "Use variable df for the dataset."
+                "Assign the resulting Plotly figure to a variable named 'fig'."
+                "Answer with just the code."
+            )
+        ),
+    ]
+    response = llm.invoke(messages)
+    code = response.content
+    local_vars = {"df": df, "px": px, "go": go}
+    code = code.replace("```", "").replace("python", "", 1)
+    exec(code, local_vars)
+    fig = local_vars.get("fig")
+    memory.chat_memory.add_user_message(user_prompt)
+    memory.chat_memory.add_ai_message(code)
+    return fig, code
+
+
+ensure_session_state()
+uploaded = st.file_uploader("Upload CSV or Excel", type=["csv", "xlsx", "xls"])
+if uploaded:
     try:
         if uploaded.name.endswith(".csv"):
             df = pd.read_csv(uploaded)
         else:
             df = pd.read_excel(uploaded)
         df = ensure_consistent_dtypes(df)
+        st.session_state.df = df
         st.dataframe(df.head())
-        fig, code = generate_plot(df, prompt)
-        if fig is not None:
-            st.plotly_chart(fig, use_container_width=True)
-            # review = agent.review_visual(prompt, fig.to_json())
-            # st.subheader("Agent Review")
-            # st.markdown(review.review)
-            # st.subheader("Agent Chain of Thought")
-            # st.markdown(review.thoughts)
     except Exception as e:
-        st.error(f"Error: {e}")
-        raise RuntimeError(e)
+        st.error(f"Error loading file: {e}")
+
+for msg in st.session_state.chat_history:
+    with st.chat_message(msg["role"]):
+        if msg.get("figure") is not None:
+            st.plotly_chart(msg["figure"], use_container_width=True)
+            st.code(msg["content"])
+        else:
+            st.markdown(msg["content"])
+
+if prompt := st.chat_input("Describe the visualization you want"):
+    st.session_state.chat_history.append({"role": "user", "content": prompt})
+    with st.chat_message("user"):
+        st.markdown(prompt)
+    df = st.session_state.get("df")
+    if df is None:
+        response = "Please upload a dataset first."
+        st.session_state.chat_history.append({"role": "assistant", "content": response})
+        with st.chat_message("assistant"):
+            st.markdown(response)
+    else:
+        try:
+            fig, code = generate_plot(st.session_state.llm, st.session_state.memory, df, prompt)
+            st.session_state.chat_history.append({"role": "assistant", "content": code, "figure": fig})
+            with st.chat_message("assistant"):
+                if fig is not None:
+                    st.plotly_chart(fig, use_container_width=True)
+                st.code(code)
+        except Exception as e:
+            error_msg = f"Error: {e}"
+            st.session_state.chat_history.append({"role": "assistant", "content": error_msg})
+            with st.chat_message("assistant"):
+                st.markdown(error_msg)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ openai
 openpyxl
 networkx
 langgraph
+langchain
+langchain-openai


### PR DESCRIPTION
## Summary
- switch Streamlit app to LangChain ChatOpenAI with in-memory conversation
- support interactive chat thread for plotting uploaded data
- add langchain and langchain-openai dependencies

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb1d38be38832fab746752f6c1b202